### PR TITLE
Add option to bypass authenticating to s3

### DIFF
--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -65,7 +65,7 @@ def get_arg_parser():
     p.add_argument(
         "--no-sign-request",
         action="store_true",
-        help="Dont use authentication when communicating to s3.",
+        help="Don't use authentication when communicating with S3.",
     )
     p.add_argument("-f", "--force", action="store_true", help="Overwrite files.")
     p.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")

--- a/s3pypi/__main__.py
+++ b/s3pypi/__main__.py
@@ -62,6 +62,11 @@ def get_arg_parser():
         action="store_true",
         help="Write a root index that lists all available package names.",
     )
+    p.add_argument(
+        "--no-sign-request",
+        action="store_true",
+        help="Dont use authentication when communicating to s3.",
+    )
     p.add_argument("-f", "--force", action="store_true", help="Overwrite files.")
     p.add_argument("-v", "--verbose", action="store_true", help="Verbose output.")
     p.add_argument("-V", "--version", action="version", version=__version__)

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -27,11 +27,7 @@ class S3Storage:
         if no_sign_request:
             _config = Config(signature_version=botocore.session.UNSIGNED)
 
-        self.s3 = session.resource(
-            "s3",
-            endpoint_url=s3_endpoint_url,
-            config=_config,
-        )
+        self.s3 = session.resource("s3", endpoint_url=s3_endpoint_url, config=_config)
         self.bucket = bucket
         self.prefix = prefix
         self.index_name = self._index if unsafe_s3_website else ""

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import boto3
 import botocore
-
 from botocore.config import Config
 
 from s3pypi.index import Index
@@ -24,14 +23,15 @@ class S3Storage:
         unsafe_s3_website: bool = False,
         no_sign_request: bool = False,
     ):
+        _config = None
         if no_sign_request:
-            self.s3 = session.resource(
-                "s3",
-                endpoint_url=s3_endpoint_url,
-                config=Config(signature_version=botocore.session.UNSIGNED)
-            )
-        else:
-            self.s3 = session.resource("s3", endpoint_url=s3_endpoint_url)
+            _config = Config(signature_version=botocore.session.UNSIGNED)
+
+        self.s3 = session.resource(
+            "s3",
+            endpoint_url=s3_endpoint_url,
+            config=_config,
+        )
         self.bucket = bucket
         self.prefix = prefix
         self.index_name = self._index if unsafe_s3_website else ""

--- a/s3pypi/storage.py
+++ b/s3pypi/storage.py
@@ -4,6 +4,8 @@ from typing import Optional
 import boto3
 import botocore
 
+from botocore.config import Config
+
 from s3pypi.index import Index
 
 
@@ -20,8 +22,16 @@ class S3Storage:
         s3_endpoint_url: Optional[str] = None,
         s3_put_args: Optional[dict] = None,
         unsafe_s3_website: bool = False,
+        no_sign_request: bool = False,
     ):
-        self.s3 = session.resource("s3", endpoint_url=s3_endpoint_url)
+        if no_sign_request:
+            self.s3 = session.resource(
+                "s3",
+                endpoint_url=s3_endpoint_url,
+                config=Config(signature_version=botocore.session.UNSIGNED)
+            )
+        else:
+            self.s3 = session.resource("s3", endpoint_url=s3_endpoint_url)
         self.bucket = bucket
         self.prefix = prefix
         self.index_name = self._index if unsafe_s3_website else ""


### PR DESCRIPTION
This allows for anonymous uploads to s3.

An example would be a setup where you are running an s3 bucket that is accessed through an s3 endpoint on a vpn'ed subnet, or in some other highly restricted way.

Tested and "works on my machine", would love to see this added.