### PR TITLE
If it looks like a path did not get expanded, expand it

### DIFF
--- a/s3pypi/core.py
+++ b/s3pypi/core.py
@@ -1,6 +1,7 @@
 import email
 import logging
 import re
+from contextlib import suppress
 from dataclasses import dataclass
 from itertools import groupby
 from operator import attrgetter
@@ -50,7 +51,7 @@ def upload_packages(
         else DummyLocker()
     )
 
-    distributions = [parse_distribution(path) for path in dist]
+    distributions = parse_distributions(dist)
     get_name = attrgetter("name")
 
     for name, group in groupby(sorted(distributions, key=get_name), get_name):
@@ -87,6 +88,19 @@ def parse_distribution(path: Path) -> Distribution:
         raise S3PyPiError(f"Unknown file type: {path}")
 
     return Distribution(name, version, path)
+
+
+def parse_distributions(paths: List[Path]) -> List[Distribution]:
+    dists = []
+    for path in paths:
+        if path.is_file():
+            dists.append(parse_distribution(path))
+        elif not path.exists():
+            expanded_paths = Path(".").glob(str(path))
+            for expanded_path in (f for f in expanded_paths if f.is_file()):
+                with suppress(S3PyPiError):
+                    dists.append(parse_distribution(expanded_path))
+    return dists
 
 
 def extract_wheel_metadata(path: Path) -> PackageMetadata:


### PR DESCRIPTION
This is another option to solve for https://github.com/gorilla-co/s3pypi/issues/88.

When a shell does not auto-expand a directory, we get a non-existant path, like "dist/*". In this pull request, when we see a path that does not exist, we attempt to use pathlib.Path.glob to expand this non existent path, and get back the path expansion that was originally intended.