### PR TITLE
Fail when dist doesn't exist

### DIFF
--- a/s3pypi/core.py
+++ b/s3pypi/core.py
@@ -100,10 +100,16 @@ def parse_distributions(paths: List[Path]) -> List[Distribution]:
         if path.is_file():
             dists.append(parse_distribution(path))
         elif not path.exists():
+            new_dists = []
             expanded_paths = Path(".").glob(str(path))
             for expanded_path in (f for f in expanded_paths if f.is_file()):
                 with suppress(S3PyPiError):
-                    dists.append(parse_distribution(expanded_path))
+                    new_dists.append(parse_distribution(expanded_path))
+            if not new_dists:
+                raise S3PyPiError(f"No valid files found matching: {path}")
+            dists.extend(new_dists)
+        else:
+            raise S3PyPiError(f"Not a file: {path}")
     return dists
 
 


### PR DESCRIPTION
Given how manual glob expansion was implemented (https://github.com/gorilla-co/s3pypi/pull/90), the program stopped failing when specifying invalid dist paths. For example, when executing `s3pypi -b my_bucket paht/with/a/typo`, the program does nothing and returns exit code 0. This is not desirable since it's impossible to know whether everything went OK or not when using the tool in automated scripts.

This PR makes it work as follows:
- If any of the specified dists is invalid, the program does nothing and it returns an exit code 1.
- For globs, if they can expand to something valid, they're considered valid. E.g. if the glob `*_package` expands to both `valid_package` and `invalid_package`, then it's considered valid and only `valid_package` is added to the dists list (this is the same as the current behaviour). However, if it only expands to invalid packages or it doesn't expand to anything, then it's invalid.
