### PR TITLE
Optimize --put-root-index

### DIFF
--- a/s3pypi/core.py
+++ b/s3pypi/core.py
@@ -68,8 +68,10 @@ def upload_packages(
                     index.filenames[filename] = Hash.of("sha256", distr.local_path)
 
     if put_root_index:
-        with storage.locked_index(storage.root) as root_index:
-            root_index.filenames = dict.fromkeys(storage.list_directories())
+        directories = storage.list_directories()
+        if directory not in directories:
+            with storage.locked_index(storage.root) as root_index:
+                root_index.filenames = dict.fromkeys(directories)
 
     if strict and existing_files:
         raise S3PyPiError(f"Found {len(existing_files)} existing files on S3")

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ python =
 [testenv]
 deps =
     boto3-stubs
-    moto
+    moto<5
     mypy
     pytest
     pytest-cov


### PR DESCRIPTION
This is an optimization for `--put-root-index`. Currently the root index is written always, and locks the root object. We only need to update the root index when a new directory is created, so we should check if the directory where we are placing the new object is in the list of directories. This is important when uploading multiple wheels simultaneously when there may be contention around the root index file.

I also bounded moto to v4 since the new version is incompatible with the current tests.